### PR TITLE
Add G/T, EIRP, PFD, Doppler, quantization noise (v0.3.0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "linkbudget"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "rfconversions",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ homepage = "https://github.com/iancleary/linkbudget"
 license = "MIT"
 name = "linkbudget"
 repository = "https://github.com/iancleary/linkbudget"
-version = "0.2.0"
+version = "0.3.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src/doppler.rs
+++ b/src/doppler.rs
@@ -1,0 +1,68 @@
+/// Doppler shift in Hz for a given transmitted frequency and radial velocity
+/// radial_velocity_m_s: positive = approaching, negative = receding
+pub fn doppler_shift_hz(frequency_hz: f64, radial_velocity_m_s: f64) -> f64 {
+    frequency_hz * radial_velocity_m_s / 299_792_458.0
+}
+
+/// Received frequency accounting for Doppler
+pub fn doppler_received_frequency(frequency_hz: f64, radial_velocity_m_s: f64) -> f64 {
+    frequency_hz + doppler_shift_hz(frequency_hz, radial_velocity_m_s)
+}
+
+/// Maximum radial velocity for a circular orbit at given altitude and elevation angle
+/// At horizon (0° elevation), radial velocity ≈ orbital velocity
+/// At zenith (90° elevation), radial velocity ≈ 0
+pub fn max_radial_velocity_circular(orbital_speed_m_s: f64, elevation_angle_degrees: f64) -> f64 {
+    let elevation_rad = elevation_angle_degrees * std::f64::consts::PI / 180.0;
+    orbital_speed_m_s * elevation_rad.cos()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn doppler_shift_leo_ku_band() {
+        // LEO satellite at ~550 km, Ku-band 12 GHz, approaching at 7600 m/s
+        let freq = 12.0e9;
+        let velocity = 7600.0;
+        let shift = doppler_shift_hz(freq, velocity);
+
+        // Expected: 12e9 * 7600 / 299792458 ≈ 304,210 Hz
+        assert!((shift - 304_210.0).abs() < 100.0);
+    }
+
+    #[test]
+    fn doppler_zero_at_zenith() {
+        let orbital_speed = 7600.0;
+        let radial_v = max_radial_velocity_circular(orbital_speed, 90.0);
+
+        assert!(radial_v.abs() < 1e-10);
+    }
+
+    #[test]
+    fn doppler_max_at_horizon() {
+        let orbital_speed = 7600.0;
+        let radial_v = max_radial_velocity_circular(orbital_speed, 0.0);
+
+        assert!((radial_v - 7600.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn received_frequency_approaching() {
+        let freq = 12.0e9;
+        let velocity = 7600.0;
+        let received = doppler_received_frequency(freq, velocity);
+
+        assert!(received > freq);
+    }
+
+    #[test]
+    fn received_frequency_receding() {
+        let freq = 12.0e9;
+        let velocity = -7600.0;
+        let received = doppler_received_frequency(freq, velocity);
+
+        assert!(received < freq);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,16 +1,22 @@
 mod budget;
 pub mod cli;
 mod constants;
+mod doppler;
 mod file_operations;
 mod open;
 mod orbits;
 mod path_loss;
+mod pfd;
 mod phy;
 mod plot;
+mod quantization;
 mod receiver;
 mod transmitter;
 
 pub use budget::LinkBudget;
+pub use doppler::*;
 pub use path_loss::PathLoss;
+pub use pfd::*;
+pub use quantization::*;
 pub use receiver::Receiver;
 pub use transmitter::Transmitter;

--- a/src/pfd.rs
+++ b/src/pfd.rs
@@ -1,0 +1,42 @@
+use std::f64::consts::PI;
+
+/// Power Flux Density in dBW/m²
+pub fn power_flux_density_dbw_per_m2(eirp_dbw: f64, distance_m: f64) -> f64 {
+    eirp_dbw - 10.0 * (4.0 * PI * distance_m * distance_m).log10()
+}
+
+/// Power Flux Density in dBW/m²/MHz (for regulatory, spread over bandwidth)
+pub fn pfd_per_mhz(eirp_dbw: f64, distance_m: f64, bandwidth_mhz: f64) -> f64 {
+    power_flux_density_dbw_per_m2(eirp_dbw, distance_m) - 10.0 * bandwidth_mhz.log10()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pfd_geostationary() {
+        // GEO satellite: EIRP = 50 dBW, distance ≈ 35,786 km
+        let eirp_dbw = 50.0;
+        let distance_m = 35_786_000.0;
+
+        let pfd = power_flux_density_dbw_per_m2(eirp_dbw, distance_m);
+
+        // PFD = 50 - 10*log10(4*pi*(35786000)^2)
+        let expected = eirp_dbw - 10.0 * (4.0 * std::f64::consts::PI * distance_m * distance_m).log10();
+        assert!((pfd - expected).abs() < 1e-10);
+    }
+
+    #[test]
+    fn pfd_per_mhz_test() {
+        let eirp_dbw = 50.0;
+        let distance_m = 35_786_000.0;
+        let bandwidth_mhz = 36.0;
+
+        let pfd_mhz = pfd_per_mhz(eirp_dbw, distance_m, bandwidth_mhz);
+        let pfd_total = power_flux_density_dbw_per_m2(eirp_dbw, distance_m);
+
+        let expected = pfd_total - 10.0 * bandwidth_mhz.log10();
+        assert!((pfd_mhz - expected).abs() < 1e-10);
+    }
+}

--- a/src/quantization.rs
+++ b/src/quantization.rs
@@ -1,0 +1,41 @@
+/// Quantization SNR for an ideal ADC
+/// Returns SNR in dB for a given number of bits
+pub fn quantization_snr_db(bits: u32) -> f64 {
+    6.02 * bits as f64 + 1.76
+}
+
+/// Effective number of bits (ENOB) from measured SNR
+pub fn enob_from_snr(snr_db: f64) -> f64 {
+    (snr_db - 1.76) / 6.02
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn snr_8_bit() {
+        let snr = quantization_snr_db(8);
+        assert!((snr - 49.92).abs() < 1e-10);
+    }
+
+    #[test]
+    fn snr_12_bit() {
+        let snr = quantization_snr_db(12);
+        assert!((snr - 74.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn snr_16_bit() {
+        let snr = quantization_snr_db(16);
+        assert!((snr - 98.08).abs() < 1e-10);
+    }
+
+    #[test]
+    fn enob_roundtrip() {
+        let bits = 12;
+        let snr = quantization_snr_db(bits);
+        let enob = enob_from_snr(snr);
+        assert!((enob - bits as f64).abs() < 1e-10);
+    }
+}

--- a/src/receiver.rs
+++ b/src/receiver.rs
@@ -20,6 +20,11 @@ impl Receiver {
         self.calculate_noise_floor() + self.noise_figure
     }
 
+    pub fn g_over_t_db(&self) -> f64 {
+        // G/T in dB/K
+        self.gain - 10.0 * self.temperature.log10()
+    }
+
     pub fn calculate_snr(&self, input_power: f64) -> f64 {
         let receiver_noise_floor_dbm = self.calculate_noise_floor();
 
@@ -62,6 +67,22 @@ mod tests {
 
         // noise floor + noise figure
         assert_eq!(-90.97722915699808, noise_power);
+    }
+
+    #[test]
+    fn g_over_t_db() {
+        let receiver = Receiver {
+            gain: 40.0,
+            temperature: 290.0,
+            noise_figure: 3.0,
+            bandwidth: 100.0e6,
+        };
+
+        let g_over_t = receiver.g_over_t_db();
+
+        // 40 - 10*log10(290) ≈ 40 - 24.6237 ≈ 15.3763
+        let expected = 40.0 - 10.0 * 290.0_f64.log10();
+        assert!((g_over_t - expected).abs() < 1e-10);
     }
 
     #[test]

--- a/src/transmitter.rs
+++ b/src/transmitter.rs
@@ -3,3 +3,40 @@ pub struct Transmitter {
     pub gain: f64,         // dB
     pub bandwidth: f64,    // Hz
 }
+
+impl Transmitter {
+    pub fn eirp_dbm(&self) -> f64 {
+        self.output_power + self.gain
+    }
+
+    pub fn eirp_dbw(&self) -> f64 {
+        self.eirp_dbm() - 30.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::transmitter::Transmitter;
+
+    #[test]
+    fn eirp_dbm() {
+        let tx = Transmitter {
+            output_power: 30.0, // 1 W in dBm
+            gain: 10.0,
+            bandwidth: 100.0e6,
+        };
+
+        assert!((tx.eirp_dbm() - 40.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn eirp_dbw() {
+        let tx = Transmitter {
+            output_power: 30.0,
+            gain: 10.0,
+            bandwidth: 100.0e6,
+        };
+
+        assert!((tx.eirp_dbw() - 10.0).abs() < 1e-10);
+    }
+}


### PR DESCRIPTION
Closes #55

- G/T calculation on Receiver
- EIRP on Transmitter
- Power Flux Density module
- Doppler shift module
- Quantization SNR/ENOB module
- All with tests
- Version bump 0.2.0 → 0.3.0