### PR TITLE
Expand tracing to remaining modules

### DIFF
--- a/src/budget.rs
+++ b/src/budget.rs
@@ -125,7 +125,15 @@ impl LinkBudget {
     pub fn link_margin_db(&self, modulation: &Modulation, target_ber: f64) -> Option<f64> {
         let actual = self.eb_no_db(modulation);
         let required = ber::required_eb_no_db(target_ber, modulation)?;
-        Some(actual - required)
+        let margin = actual - required;
+        tracing::debug!(
+            actual_eb_no_db = actual,
+            required_eb_no_db = required,
+            margin_db = margin,
+            target_ber,
+            "Link margin"
+        );
+        Some(margin)
     }
 
     /// Link margin in dB for a coded modulation and target BER.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -111,7 +111,7 @@ impl Command {
                 open::plot(output_html_path.clone());
             }
             Err(e) => {
-                eprintln!("Error generating HTML table: {}", e);
+                tracing::error!("Error generating HTML table: {}", e);
             }
         }
 

--- a/src/orbits/slant_range.rs
+++ b/src/orbits/slant_range.rs
@@ -33,7 +33,15 @@ impl SlantRange {
                 - f64::cos(elevation_angle_radians) * f64::cos(elevation_angle_radians),
         );
 
-        self.body_radius * (inner_term - f64::sin(elevation_angle_radians))
+        let slant_range = self.body_radius * (inner_term - f64::sin(elevation_angle_radians));
+        tracing::trace!(
+            elevation_deg = self.elevation_angle_degrees,
+            altitude_m = self.altitude,
+            body_radius_m = self.body_radius,
+            slant_range_m = slant_range,
+            "Slant range calculated"
+        );
+        slant_range
     }
 }
 

--- a/src/plot.rs
+++ b/src/plot.rs
@@ -12,6 +12,7 @@ pub fn generate_html_summary(
     output_path_str: &str,
 ) -> Result<(), std::io::Error> {
     let path = Path::new(output_path_str);
+    tracing::debug!(output_path = output_path_str, "Generating HTML summary");
     let mut file = File::create(path)?;
 
     let svg = generate_svg(budget);

--- a/src/sensitivity.rs
+++ b/src/sensitivity.rs
@@ -95,6 +95,15 @@ pub fn sensitivity_matched_filter_dbm(
         + 10.0 * info_bit_rate_bps.log10()
         + implementation_loss_db;
 
+    tracing::debug!(
+        required_eb_no_db,
+        noise_figure_db,
+        info_bit_rate_bps,
+        implementation_loss_db,
+        sensitivity_dbm = sensitivity,
+        "Matched filter sensitivity"
+    );
+
     Some(sensitivity)
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #67 — Codex assessed all 19 source files and identified modules needing additional tracing.

## Codex Assessment Results

| File | Action | Rationale |
|---|---|---|
| `budget.rs` | ✅ Added | Link margin: actual/required Eb/No + margin at debug level |
| `sensitivity.rs` | ✅ Added | Matched filter sensitivity with all terms at debug level |
| `plot.rs` | ✅ Added | HTML summary generation start |
| `orbits/slant_range.rs` | ✅ Added | Geometric calculation with all intermediates at trace level |
| `cli.rs` | ✅ Converted | eprintln → tracing::error |
| `ber.rs` | ⏭️ Skip | Bisection is isolated; tracing at sensitivity level covers it |
| `coding.rs` | ⏭️ Skip | Rate/gain extracted at budget level |
| `energy.rs` | ⏭️ Skip | Direct dB arithmetic |
| `receiver.rs` | ⏭️ Skip | Simple noise composition |
| `transmitter.rs`, `doppler.rs`, `pfd.rs`, `phy.rs`, `evm.rs`, `quantization.rs`, `modulation.rs`, `constants.rs`, `orbits/mod.rs`, `orbits/circular.rs` | ⏭️ Skip | Direct formulas, no branching |

All 196 tests pass.