### PR TITLE
Polish crate quality checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,8 +26,8 @@ jobs:
         run: cargo test --all-features --verbose
       - name: Check documentation
         run: RUSTDOCFLAGS="-D warnings" cargo doc --all-features --no-deps --verbose
-      - name: Package dry run
-        run: cargo package --dry-run --verbose
+      - name: Verify package
+        run: cargo package --verbose
       - name: Build project
         run: cargo build --all-features --verbose
       - name: Publish (on tag)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,16 +12,24 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build_and_test:
+  quality:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Use Rust stable
         run: rustup update stable && rustup default stable
-      - name: Build project
-        run: cargo build --verbose
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+      - name: Run clippy
+        run: cargo clippy --all-targets --all-features -- -D warnings
       - name: Run tests
-        run: cargo test --verbose
+        run: cargo test --all-features --verbose
+      - name: Check documentation
+        run: RUSTDOCFLAGS="-D warnings" cargo doc --all-features --no-deps --verbose
+      - name: Package dry run
+        run: cargo package --dry-run --verbose
+      - name: Build project
+        run: cargo build --all-features --verbose
       - name: Publish (on tag)
         if: github.ref_type == 'tag'
         run: cargo publish --verbose

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,9 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
+permissions:
+  contents: read
+
 jobs:
   quality:
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,8 +18,7 @@ repos:
     -   id: rust-clippy
         name: Rust clippy
         description: Run cargo clippy on files included in the commit. clippy should be installed before-hand.
-        entry: cargo clippy --all-targets --all-features -- -Dclippy::all
-        # cargo clippy --all-targets --all-features --fix -- -Dclippy::all
+        entry: cargo clippy --all-targets --all-features -- -D warnings
         pass_filenames: false
         types: [file, rust]
         language: system

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,10 +4,14 @@ description = "A link budget toolbox for satellite communications"
 documentation = "https://docs.rs/linkbudget"
 edition = "2021"
 homepage = "https://github.com/iancleary/linkbudget"
+keywords = ["rf", "satellite", "link-budget", "communications"]
 license = "MIT"
 name = "linkbudget"
+readme = "README.md"
 repository = "https://github.com/iancleary/linkbudget"
+rust-version = "1.70"
 version = "0.6.1"
+categories = ["science", "simulation"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 RF link budget analysis for satellite and terrestrial communication systems.
 
 [![Crates.io](https://img.shields.io/crates/v/linkbudget.svg)](https://crates.io/crates/linkbudget)
+[![Docs.rs](https://docs.rs/linkbudget/badge.svg)](https://docs.rs/linkbudget)
 
 ## Features
 

--- a/justfile
+++ b/justfile
@@ -9,8 +9,16 @@ fmt:
 # alias for fmt
 format: fmt
 
-# lint the code
+# check formatting without writing changes
+fmt-check:
+	cargo fmt --all -- --check
+
+# lint the code without writing changes
 lint:
+	cargo clippy --all-targets --all-features -- -D warnings
+
+# apply automatic clippy fixes
+lint-fix:
 	cargo clippy --all-targets --all-features --fix -- -Dclippy::all
 
 # run the crate
@@ -23,7 +31,18 @@ build:
 
 # run tests
 test:
-  cargo test
+  cargo test --all-features
 
-# Lint and then test targets (like CI does)
-ci: lint test build
+# check documentation with rustdoc warnings denied
+doc-check:
+  RUSTDOCFLAGS="-D warnings" cargo doc --all-features --no-deps
+
+# verify package contents without publishing
+package:
+  cargo package --dry-run
+
+# format, lint, test, document, and package like CI
+check: fmt-check lint test doc-check package
+
+# run checks and build
+ci: check build

--- a/justfile
+++ b/justfile
@@ -39,7 +39,7 @@ doc-check:
 
 # verify package contents without publishing
 package:
-  cargo package --dry-run
+  cargo package
 
 # format, lint, test, document, and package like CI
 check: fmt-check lint test doc-check package

--- a/src/budget.rs
+++ b/src/budget.rs
@@ -158,7 +158,7 @@ impl LinkBudget {
 #[cfg(test)]
 mod budget_tests {
     use super::*;
-    use crate::coding::{dvbs2_qpsk_r34, FecCode};
+    use crate::coding::dvbs2_qpsk_r34;
 
     fn sample_budget() -> LinkBudget {
         LinkBudget {
@@ -203,7 +203,7 @@ mod budget_tests {
     fn ber_returns_valid_value() {
         let b = sample_budget();
         let ber_val = b.ber(&Modulation::Qpsk);
-        assert!(ber_val >= 0.0 && ber_val <= 0.5);
+        assert!((0.0..=0.5).contains(&ber_val));
     }
 
     #[test]

--- a/tests/readme_examples.rs
+++ b/tests/readme_examples.rs
@@ -91,7 +91,7 @@ fn link_budget_eb_no_qpsk() {
 fn link_budget_ber_valid() {
     let b = ka_band_leo();
     let ber_val = b.ber(&Modulation::Qpsk);
-    assert!(ber_val >= 0.0 && ber_val <= 0.5);
+    assert!((0.0..=0.5).contains(&ber_val));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Add crates.io metadata for README, keywords, categories, and Rust version.
- Split the mutating clippy fix recipe into `lint-fix` and make `lint` a non-mutating `-D warnings` check.
- Expand CI/local quality checks to include formatting, clippy with warnings denied, all-feature tests, rustdoc warnings denied, non-publishing package verification, and all-feature build.
- Add a docs.rs badge next to the crates.io badge.
- Add read-only workflow permissions and align the pre-commit clippy hook with CI's non-mutating lint check.

## Checks run

- `gh repo view iancleary/linkbudget --json nameWithOwner,url,isArchived,isPrivate,visibility,defaultBranchRef,pushedAt,description,sshUrl` - public, active, not archived, default branch `main`
- `gh pr list --repo iancleary/linkbudget --state open --json number,title,author,headRefName,url,updatedAt` - found this existing equivalent PR and updated it instead of opening a duplicate
- `python3 - <<'PY' ... crates.io api ... PY` - confirmed crates.io `linkbudget` newest/max version `0.6.1`, repository/docs metadata present
- `curl -sSLI https://docs.rs/linkbudget/latest/linkbudget/ | sed -n '1,35p'` - docs.rs returned HTTP 200
- `cargo metadata --no-deps --format-version 1` - confirmed root Cargo crate metadata and targets
- `git diff --check` - passed
- `python3 -c 'import pathlib, yaml; yaml.safe_load(pathlib.Path(".pre-commit-config.yaml").read_text()); yaml.safe_load(pathlib.Path(".github/workflows/ci.yml").read_text()); print("yaml ok")'` - passed
- `cargo fmt --all -- --check` - passed
- `cargo clippy --all-targets --all-features -- -D warnings` - passed
- `cargo test --all-features` - passed: 151 unit tests, 39 README example tests, 6 scenario tests, 0 doc tests
- `RUSTDOCFLAGS='-D warnings' cargo doc --no-deps --all-features` - passed
- `cargo package --list >/tmp/linkbudget-package-list.txt` - passed
- `cargo package` - passed

## Notes/risks

- The existing release publish step is preserved, but CI now performs non-publishing `cargo package --verbose` verification before it.
- `rust-version = "1.70"` is intentionally conservative for an edition 2021 crate; local validation was run with Cargo/Rust 1.96.1.
- `just check` / `just ci` were identified as the project-specific command path but not run because `just` is not installed in this environment; the equivalent underlying Cargo checks above passed.
- Optional security tools were not run: `cargo audit`, `cargo deny`, `cargo machete`, and `cargo semver-checks` are not installed in this environment.
- GitHub reported one low Dependabot vulnerability on the default branch during push; dependency/security review is deferred to Ian or a dedicated Dependabot/security PR.
