### PR TITLE
sync CI workflow with justfile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
   quality:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Use Rust stable
         run: rustup update stable && rustup default stable
       - name: Check formatting
@@ -26,13 +26,13 @@ jobs:
       - name: Run clippy
         run: cargo clippy --all-targets --all-features -- -D warnings
       - name: Run tests
-        run: cargo test --all-features --verbose
+        run: cargo test --all-features
       - name: Check documentation
-        run: RUSTDOCFLAGS="-D warnings" cargo doc --all-features --no-deps --verbose
+        run: RUSTDOCFLAGS="-D warnings" cargo doc --all-features --no-deps
       - name: Verify package
-        run: cargo package --verbose
+        run: cargo package
       - name: Build project
-        run: cargo build --all-features --verbose
+        run: cargo build --release
       - name: Publish (on tag)
         if: github.ref_type == 'tag'
         run: cargo publish --verbose

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 jobs:
-  quality:
+  ci:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/justfile
+++ b/justfile
@@ -44,7 +44,7 @@ package:
 # format, lint, test, document, and package like CI
 check: fmt-check lint test doc-check package
 
-# run checks and build
+# run the same checks and build mirrored by CI
 ci: check build
 
 # Cut a GitHub release for an explicit SemVer version.

--- a/justfile
+++ b/justfile
@@ -21,14 +21,6 @@ lint:
 lint-fix:
 	cargo clippy --all-targets --all-features --fix -- -Dclippy::all
 
-# run the crate
-dev:
-  cargo run
-
-# build the crate
-build:
-  cargo build --release
-
 # run tests
 test:
   cargo test --all-features
@@ -40,6 +32,14 @@ doc-check:
 # verify package contents without publishing
 package:
   cargo package
+
+# build the crate
+build:
+  cargo build --release
+
+# run the crate
+dev:
+  cargo run
 
 # format, lint, test, document, and package like CI
 check: fmt-check lint test doc-check package

--- a/justfile
+++ b/justfile
@@ -4,42 +4,38 @@ help:
 
 # format the code
 fmt:
-	cargo fmt --all
+    cargo fmt --all
 
 # alias for fmt
 format: fmt
 
 # check formatting without writing changes
 fmt-check:
-	cargo fmt --all -- --check
+    cargo fmt --all -- --check
 
 # lint the code without writing changes
 lint:
-	cargo clippy --all-targets --all-features -- -D warnings
+    cargo clippy --all-targets --all-features -- -D warnings
 
 # apply automatic clippy fixes
 lint-fix:
-	cargo clippy --all-targets --all-features --fix -- -Dclippy::all
+    cargo clippy --all-targets --all-features --fix -- -D warnings
 
 # run tests
 test:
-  cargo test --all-features
+    cargo test --all-features
 
 # check documentation with rustdoc warnings denied
 doc-check:
-  RUSTDOCFLAGS="-D warnings" cargo doc --all-features --no-deps
+    RUSTDOCFLAGS="-D warnings" cargo doc --all-features --no-deps
 
 # verify package contents without publishing
 package:
-  cargo package
+    cargo package
 
 # build the crate
 build:
-  cargo build --release
-
-# run the crate
-dev:
-  cargo run
+    cargo build --release
 
 # format, lint, test, document, and package like CI
 check: fmt-check lint test doc-check package
@@ -49,4 +45,8 @@ ci: check build
 
 # Cut a GitHub release for an explicit SemVer version.
 cut-release *args:
-  ./scripts/cut-release.sh {{args}}
+    ./scripts/cut-release.sh {{args}}
+
+# run the crate
+dev:
+    cargo run


### PR DESCRIPTION
## Summary
- Update CI to use `actions/checkout@v7`.
- Mirror the justfile CI command sequence directly in the workflow without installing or invoking `just`.
- Clarify the justfile `ci` recipe comment as the workflow mirror point.

## Checks
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features`
- `RUSTDOCFLAGS="-D warnings" cargo doc --all-features --no-deps`
- `cargo package`
- `cargo build --release`